### PR TITLE
feat: Replace AWS S3 file uploads with Azure Blob Storage integration.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Azure Storage Configuration
+# Set these in your Azure App Service -> Settings -> Environment variables
+
+# The endpoint of your Blob Storage account
+SPRING_CLOUD_AZURE_STORAGE_BLOB_ENDPOINT=https://<your-storage-account>.blob.core.windows.net
+
+# The name of the container to upload files to
+SPRING_CLOUD_AZURE_STORAGE_BLOB_CONTAINER_NAME=<your-container-name>
+
+# Your Storage Account Name
+SPRING_CLOUD_AZURE_STORAGE_BLOB_ACCOUNT_NAME=<your-account-name>
+
+# Your Storage Account Access Key
+# (Not required if using Managed Identity with correct RBAC roles)
+SPRING_CLOUD_AZURE_STORAGE_BLOB_ACCOUNT_KEY=<your-account-key>

--- a/build.gradle
+++ b/build.gradle
@@ -64,11 +64,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.session:spring-session-data-redis'
 
-	//S3
-	implementation platform("software.amazon.awssdk:bom:2.25.39") // 최신 권장
-	implementation "software.amazon.awssdk:s3"
-	implementation "software.amazon.awssdk:s3-transfer-manager"
-	implementation "software.amazon.awssdk:netty-nio-client"
+	//Azure Storage
+	implementation 'com.azure.spring:spring-cloud-azure-starter-storage-blob:5.19.0'
 
 	//http5
 	implementation 'org.apache.httpcomponents.client5:httpclient5'
@@ -76,9 +73,7 @@ dependencies {
 
 
 }
-configurations.configureEach {
-	exclude group: "com.amazonaws", module: "aws-java-sdk-s3"
-}
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/com/full/moon/domain/book/service/BookService.java
+++ b/src/main/java/com/full/moon/domain/book/service/BookService.java
@@ -27,7 +27,7 @@ import com.full.moon.global.exception.CustomException;
 import com.full.moon.global.exception.ErrorCode;
 import com.full.moon.global.security.oauth.entity.CustomOAuth2User;
 import com.full.moon.global.utils.UserUtils;
-import com.full.moon.infra.s3.service.S3Service;
+import com.full.moon.infra.azure.service.AzureStorageService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +37,7 @@ import lombok.RequiredArgsConstructor;
 public class BookService {
 
 	private final BookRepository bookRepository;
-	private final S3Service s3Service;
+	private final AzureStorageService azureStorageService;
 	private final UserRepository userRepository;
 	private final ChildRepository childRepository;
 	private final UserUtils userUtils;
@@ -51,7 +51,7 @@ public class BookService {
 
 		Child child = findChild(childId,user);
 
-		String imgUrl = s3Service.uploadFile(file);
+		String imgUrl = azureStorageService.uploadFile(file);
 
 		Book book = Book.builder()
 			.bookCoverUrl(imgUrl)

--- a/src/main/java/com/full/moon/domain/bookpage/service/BookPageService.java
+++ b/src/main/java/com/full/moon/domain/bookpage/service/BookPageService.java
@@ -26,7 +26,7 @@ import com.full.moon.global.exception.CustomException;
 import com.full.moon.global.exception.ErrorCode;
 import com.full.moon.global.security.oauth.entity.CustomOAuth2User;
 import com.full.moon.global.utils.UserUtils;
-import com.full.moon.infra.s3.service.S3Service;
+import com.full.moon.infra.azure.service.AzureStorageService;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -39,7 +39,7 @@ public class BookPageService {
 	private final BookPageRepository bookPageRepository;
 	private final ChildRepository childRepository;
 	private final BookRepository bookRepository;
-	private final S3Service s3Service;
+	private final AzureStorageService azureStorageService;
 	private final UserUtils userUtils;
 	private final WebClient fastApiWebClient;
 
@@ -54,7 +54,7 @@ public class BookPageService {
 		Book book = bookRepository.findByIdAndChild(bookId,child)
 			.orElseThrow(()->new CustomException(ErrorCode.NO_BOOK));
 
-		String imgUrl = s3Service.uploadFile(file);
+		String imgUrl = azureStorageService.uploadFile(file);
 		//여기서 FastAPI server로 요청보냄
 
 		String videoUrl = processBlocking(imgUrl);

--- a/src/main/java/com/full/moon/domain/child/service/ChildService.java
+++ b/src/main/java/com/full/moon/domain/child/service/ChildService.java
@@ -14,7 +14,7 @@ import com.full.moon.domain.user.repository.UserRepository;
 import com.full.moon.global.exception.CustomException;
 import com.full.moon.global.exception.ErrorCode;
 import com.full.moon.global.security.oauth.entity.CustomOAuth2User;
-import com.full.moon.infra.s3.service.S3Service;
+import com.full.moon.infra.azure.service.AzureStorageService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,7 +24,7 @@ public class ChildService {
 
 	private final ChildRepository childRepository;
 	private final UserRepository userRepository;
-	private final S3Service s3Service;
+	private final AzureStorageService azureStorageService;
 
 
 	public ChildResponse makeChild(CustomOAuth2User customOAuth2User, MultipartFile file, String name){
@@ -32,7 +32,7 @@ public class ChildService {
 		User user =  userRepository.findById(Long.parseLong(customOAuth2User.getUserId()))
 			.orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-		String imgUrl = s3Service.uploadFile(file);
+		String imgUrl = azureStorageService.uploadFile(file);
 
 		Child child = Child.builder()
 			.name(name)
@@ -76,7 +76,7 @@ public class ChildService {
 		Child child = childRepository.findByIdAndUser(childId,user)
 			.orElseThrow(()->new CustomException(ErrorCode.NO_CHILD));
 
-		String imgUrl = s3Service.uploadFile(file);
+		String imgUrl = azureStorageService.uploadFile(file);
 
 		child.setName(name);
 		child.setPhotoUrl(imgUrl);

--- a/src/main/java/com/full/moon/infra/azure/service/AzureStorageService.java
+++ b/src/main/java/com/full/moon/infra/azure/service/AzureStorageService.java
@@ -1,0 +1,54 @@
+package com.full.moon.infra.azure.service;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobHttpHeaders;
+import com.full.moon.global.exception.CustomException;
+import com.full.moon.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AzureStorageService {
+
+	@Value("${spring.cloud.azure.storage.blob.container-name}")
+	private String containerName;
+
+	private final BlobServiceClient blobServiceClient;
+
+	public String uploadFile(MultipartFile file) {
+		try {
+			String originalFilename = file.getOriginalFilename();
+			String extension = "";
+			if (originalFilename != null && originalFilename.contains(".")) {
+				extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+			}
+			String fileName = UUID.randomUUID() + extension;
+			
+			BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(containerName);
+			BlobClient blobClient = containerClient.getBlobClient(fileName);
+
+			BlobHttpHeaders headers = new BlobHttpHeaders().setContentType(file.getContentType());
+			
+			blobClient.upload(file.getInputStream(), file.getSize(), true);
+			blobClient.setHttpHeaders(headers);
+
+			return blobClient.getBlobUrl();
+
+		} catch (IOException e) {
+			log.error("Azure Storage upload error", e);
+			throw new CustomException(ErrorCode.UPLOAD_FAIL);
+		}
+	}
+}


### PR DESCRIPTION
## 📝 요약(Summary)

**AWS S3에서 Azure Blob Storage로 파일 업로드 기능을 마이그레이션했습니다.**

- **의존성 변경**: `build.gradle`에서 AWS SDK를 제거하고 `spring-cloud-azure-starter-storage-blob`을 추가했습니다.
- **기능 구현**: `AzureStorageService`를 새로 구현하여 Azure Blob Storage에 파일을 업로드하도록 변경했습니다.
- **리팩토링**: 기존에 `S3Service`를 사용하던 도메인 서비스(`BookService`, `ChildService`, `BookPageService`)들이 `AzureStorageService`를 사용하도록 수정했습니다.
- **구성 관리**: Azure App Service 배포를 위한 환경변수 목록을 `.env.example` 파일로 문서화했습니다.

## 📸 기능 스크린 샷 공유

<!--- 기능 테스트 결과 스크린샷이 있다면 첨부해주세요 -->

## 💬 공유사항 to 리뷰어

- **배포 시 설정**: Azure App Service의 '구성(Configuration)' 메뉴에서 `.env.example`에 명시된 환경변수(`SPRING_CLOUD_AZURE_STORAGE_BLOB_ENDPOINT` 등)를 반드시 등록해야 합니다.
- **S3 코드 정리**: 기존 `S3Service.java` 및 `S3Controller.java`는 더 이상 사용되지 않으므로 삭제가 권장됩니다.
- **테스트**: 로컬 환경 또는 배포 환경에서 파일 업로드 테스트가 필요합니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).